### PR TITLE
use manifest json to resolve templates names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tinystacks/predeploy-infra",
-  "version": "1.0.1-local.3",
+  "version": "1.0.1-local.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tinystacks/predeploy-infra",
-      "version": "1.0.1-local.3",
+      "version": "1.0.1-local.4",
       "license": "ISC",
       "dependencies": {
         "colors": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinystacks/predeploy-infra",
-  "version": "1.0.1-local.3",
+  "version": "1.0.1-local.4",
   "description": "## CLI Options",
   "main": "dist/exported-types.js",
   "files": [

--- a/src/commands/smoke-test/parser/aws-cdk/index.ts
+++ b/src/commands/smoke-test/parser/aws-cdk/index.ts
@@ -68,6 +68,13 @@ function parseDiffLine (diff: string): CdkDiff {
   };
 }
 
+function resolveTemplateName (stackName: string): string {
+  const manifest: Json = JSON.parse(readFileSync(resolvePath('./cdk.out/manifest.json')).toString() || '{}');
+  const { artifacts = {} } = manifest;
+  const templateArtifact: Json = Object.values(artifacts).find((artifact: Json) => artifact.displayName === stackName);
+  return templateArtifact?.properties?.templateFile;
+}
+
 const parsers: {
   [parserName: string]: AwsCdkParser
 } = {};
@@ -126,7 +133,8 @@ async function parseCdkResource (diff: CdkDiff, cloudformationTemplate: Json, co
 }
 
 async function composeCdkResourceDiffRecords (stackName: string, diffs: string[] = [], config: SmokeTestOptions = {}): Promise<ResourceDiffRecord[]> {
-  const templateJson: Json = JSON.parse(readFileSync(resolvePath(`./cdk.out/${stackName}.template.json`)).toString() || '{}');
+  const templateName = resolveTemplateName(stackName);
+  const templateJson: Json = JSON.parse(readFileSync(resolvePath(`./cdk.out/${templateName}`)).toString() || '{}');
   const resources: ResourceDiffRecord[] = [];
   for (const diff of diffs) {
     const cdkDiff: CdkDiff = parseDiffLine(diff);

--- a/test/commands/smoke-test/parser/aws-cdk/index.test.ts
+++ b/test/commands/smoke-test/parser/aws-cdk/index.test.ts
@@ -26,7 +26,7 @@ import { ChangeType, IacFormat } from '../../../../../src/types';
 const fs = require('fs');
 const path = require('path');
 const mockCdkDiff = fs.realRFS(path.realResolve(__dirname, '../../test-data/simple-sqs-stack/MockCdkDiff.txt')).toString();
-
+const mockManifest = fs.realRFS(path.realResolve(__dirname, '../../test-data/simple-sqs-stack/MockCdkTemplate.json'));
 const mockCdkTemplate = fs.realRFS(path.realResolve(__dirname, '../../test-data/simple-sqs-stack/MockCdkTemplate.json'));
 
 describe('aws-cdk parser', () => {
@@ -38,6 +38,7 @@ describe('aws-cdk parser', () => {
   });
 
   it('parseCdkDiff', async () => {
+    mockReadFileSync.mockReturnValueOnce(mockManifest);
     mockReadFileSync.mockReturnValueOnce(mockCdkTemplate);
 
     const result = await parseCdkDiff(mockCdkDiff, {});

--- a/test/commands/smoke-test/test-data/simple-sqs-stack/manifest.json
+++ b/test/commands/smoke-test/test-data/simple-sqs-stack/manifest.json
@@ -1,0 +1,76 @@
+{
+  "version": "20.0.0",
+  "artifacts": {
+    "Tree": {
+      "type": "cdk:tree",
+      "properties": {
+        "file": "tree.json"
+      }
+    },
+    "TestStack.assets": {
+      "type": "cdk:asset-manifest",
+      "properties": {
+        "file": "TestStack.assets.json",
+        "requiresBootstrapStackVersion": 6,
+        "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version"
+      }
+    },
+    "TestStack": {
+      "type": "aws:cloudformation:stack",
+      "environment": "aws://unknown-account/unknown-region",
+      "properties": {
+        "templateFile": "TestStack.template.json",
+        "validateOnSynth": false,
+        "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-deploy-role-${AWS::AccountId}-${AWS::Region}",
+        "cloudFormationExecutionRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-cfn-exec-role-${AWS::AccountId}-${AWS::Region}",
+        "stackTemplateAssetObjectUrl": "s3://cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}/6561fc934770d0fab62c927a7695f8dae4337b99f0718104325f9562ba392858.json",
+        "requiresBootstrapStackVersion": 6,
+        "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version",
+        "additionalDependencies": [
+          "TestStack.assets"
+        ],
+        "lookupRole": {
+          "arn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-lookup-role-${AWS::AccountId}-${AWS::Region}",
+          "requiresBootstrapStackVersion": 8,
+          "bootstrapStackVersionSsmParameter": "/cdk-bootstrap/hnb659fds/version"
+        }
+      },
+      "dependencies": [
+        "TestStack.assets"
+      ],
+      "metadata": {
+        "/TestStack/SmokeTestQueue/Resource": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "SmokeTestQueueB0847F6A"
+          }
+        ],
+        "/TestStack/CDKMetadata/Default": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "CDKMetadata"
+          }
+        ],
+        "/TestStack/CDKMetadata/Condition": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "CDKMetadataAvailable"
+          }
+        ],
+        "/TestStack/BootstrapVersion": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "BootstrapVersion"
+          }
+        ],
+        "/TestStack/CheckBootstrapVersion": [
+          {
+            "type": "aws:cdk:logicalId",
+            "data": "CheckBootstrapVersion"
+          }
+        ]
+      },
+      "displayName": "TestStack"
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [x] Bug Fix

## Link to Notion Task or Github Issue
N/A - testing

## Summary of Bug Fix(es)
Long stack names result in truncated template file names.
This adds logic to use the manifest to lookup the template file names using the stack name.