### PR TITLE
fix stack name extraction from cdk diff

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -1,1 +1,1 @@
-
+1. Update AWS CDK diff parser to account for different Stack name and construct id.

--- a/src/commands/check/parser/aws-cdk/index.ts
+++ b/src/commands/check/parser/aws-cdk/index.ts
@@ -171,7 +171,7 @@ async function parseStackDiff (stackDiffLines: DiffSection, config: CheckOptions
   const diffHeaders = ['IAM Statement Changes', 'IAM Policy Changes', 'Parameters', 'Resources', 'Outputs', 'Other Changes'];
   // Control for when stackName is set in cdk.StackProps
   // If this is set, and differs from the Stack's construct id,
-  // the section header is "Stack StackConstructId (StackName)"" instead of "Stack StackName"
+  // the section header is "Stack StackConstructId (StackName)" instead of "Stack StackName"
   const stackName = sectionName.includes(' ') ? sectionName.split(' ').at(0) : sectionName;
 
   const diffSections = partitionDiff(diffLines, diffHeaders);

--- a/src/commands/check/parser/aws-cdk/index.ts
+++ b/src/commands/check/parser/aws-cdk/index.ts
@@ -165,10 +165,14 @@ async function composeCdkResourceDiffRecords (stackName: string, diffs: string[]
 
 async function parseStackDiff (stackDiffLines: DiffSection, config: CheckOptions): Promise<ResourceDiffRecord[]> {
   const {
-    sectionName: stackName,
+    sectionName,
     diffLines
   } = stackDiffLines;
   const diffHeaders = ['IAM Statement Changes', 'IAM Policy Changes', 'Parameters', 'Resources', 'Outputs', 'Other Changes'];
+  // Control for when stackName is set in cdk.StackProps
+  // If this is set, and differs from the Stack's construct id,
+  // the section header is "Stack StackConstructId (StackName)"" instead of "Stack StackName"
+  const stackName = sectionName.includes(' ') ? sectionName.split(' ').at(0) : sectionName;
 
   const diffSections = partitionDiff(diffLines, diffHeaders);
   const resourceDiffs = diffSections.find(diffSection => diffSection.sectionName === 'Resources');

--- a/test/commands/check/parser/aws-cdk/index.test.ts
+++ b/test/commands/check/parser/aws-cdk/index.test.ts
@@ -61,4 +61,35 @@ describe('aws-cdk parser', () => {
     expect(result[2]).toHaveProperty('resourceType', 'AWS::SQS::Queue');
     expect(result[2]).toHaveProperty('changeType', ChangeType.UPDATE);
   });
+  
+  it('parseCdkDiff with specified stack name', async () => {
+    mockReadFileSync.mockReturnValueOnce(mockManifest);
+    mockReadFileSync.mockReturnValueOnce(mockCdkTemplate);
+
+    const diff = mockCdkDiff.split('\n');
+    const firstLine = diff.at(0);
+    const [stackHeader, stackName] = firstLine.split(' ');
+    const alteredFirstLine = [stackHeader, stackName, `(${stackName}Name)`].join(' ');
+    diff[0] = alteredFirstLine;
+
+    const result = await parseCdkDiff(diff.join('\n'), {});
+
+    expect(Array.isArray(result)).toEqual(true);
+    expect(result.length).toEqual(3);
+
+    expect(result[0]).toHaveProperty('stackName', 'TestStack');
+    expect(result[0]).toHaveProperty('format', IacFormat.awsCdk);
+    expect(result[0]).toHaveProperty('resourceType', 'AWS::SQS::Queue');
+    expect(result[0]).toHaveProperty('changeType', ChangeType.DELETE);
+    
+    expect(result[1]).toHaveProperty('stackName', 'TestStack');
+    expect(result[1]).toHaveProperty('format', IacFormat.awsCdk);
+    expect(result[1]).toHaveProperty('resourceType', 'AWS::SQS::Queue');
+    expect(result[1]).toHaveProperty('changeType', ChangeType.CREATE);
+    
+    expect(result[2]).toHaveProperty('stackName', 'TestStack');
+    expect(result[2]).toHaveProperty('format', IacFormat.awsCdk);
+    expect(result[2]).toHaveProperty('resourceType', 'AWS::SQS::Queue');
+    expect(result[2]).toHaveProperty('changeType', ChangeType.UPDATE);
+  });
 });


### PR DESCRIPTION
## Pull Request Type
 - [ ] Feature
 - [x] Bug Fix

## Link to Notion Task or Github Issue
N/A - discovered in integration testing

## Summary of Bug Fix(es)
### Previous Behaviour
_Description of the bug and it's impact_
CDK diff parser assumed the header section per stack followed a format of `Stack ${StackName}`.  This is only true if the Stack's construct id and name are the same.  In the case that they differ, this section header is formatted as `Stack ${StackConstructId} ${StackName}`.  In this situation, we need to parse the `StackConstructId` out of the trailing partition of the section header in order to identify the template in the manifest.json.

### New Behaviour
_Description of the bug fix and it's impact_
Since `Stack ` is already trimmed from the section header when deducing the stack's identifier in the manifest, now we perform a simplistic check to verify there is only one string left and if there are multiple (indicated by white space) we take the first as the construct id.